### PR TITLE
Update .gitignore to exclude bin and obj directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /Vectorize/Vectorize.SourceGenerator/bin/Debug/netstandard2.0
 /Vectorize/Vectorize.SourceGenerator/obj
 /Vectorize/Vectorize.Sample
+/bin
+/obj


### PR DESCRIPTION
Add `/bin` and `/obj` directories to the `.gitignore` file.

* Add `/bin` to the list of ignored directories
* Add `/obj` to the list of ignored directories

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JanTamis/Vectorize/pull/4?shareId=ad21d3da-d81d-4d8e-a537-f60a485552ea).